### PR TITLE
Add link/unlink location to flight

### DIFF
--- a/src/main/java/seedu/address/logic/core/WingmanParser.java
+++ b/src/main/java/seedu/address/logic/core/WingmanParser.java
@@ -15,6 +15,8 @@ import seedu.address.logic.flight.linkplane.LinkPlaneCommandFactory;
 import seedu.address.logic.flight.unlinkplane.UnlinkPlaneCommandFactory;
 import seedu.address.logic.location.addlocation.AddLocationCommandFactory;
 import seedu.address.logic.location.deletelocation.DeleteLocationCommandFactory;
+import seedu.address.logic.location.linklocation.LinkLocationCommandFactory;
+import seedu.address.logic.location.unlinklocation.UnlinkLocationCommandFactory;
 import seedu.address.logic.pilot.addpilot.AddPilotCommandFactory;
 import seedu.address.logic.pilot.deletepilot.DeletePilotCommandFactory;
 import seedu.address.logic.plane.addplane.AddPlaneCommandFactory;
@@ -45,7 +47,9 @@ public class WingmanParser extends FactoryParser {
         )),
         new CommandGroup(OperationMode.LOCATION, List.of(
                 new AddLocationCommandFactory(),
-                new DeleteLocationCommandFactory()
+                new DeleteLocationCommandFactory(),
+                new LinkLocationCommandFactory(),
+                new UnlinkLocationCommandFactory()
         )),
         new CommandGroup(OperationMode.FLIGHT, List.of(
                 new AddFlightCommandFactory(),

--- a/src/main/java/seedu/address/logic/location/linklocation/LinkLocationCommand.java
+++ b/src/main/java/seedu/address/logic/location/linklocation/LinkLocationCommand.java
@@ -5,7 +5,9 @@ import seedu.address.logic.core.CommandResult;
 import seedu.address.logic.core.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.flight.Flight;
+import seedu.address.model.flight.exceptions.FlightNotFoundException;
 import seedu.address.model.location.Location;
+import seedu.address.model.location.exceptions.LocationNotFoundException;
 
 
 /**
@@ -42,9 +44,31 @@ public class LinkLocationCommand implements Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        Flight flightToLink = model.getFlightById(flightId);
-        Location departureLocationToLink = model.getLocationById(departureLocationId);
-        Location arrivalLocationToLink = model.getLocationById(arrivalLocationId);
+        Flight flightToLink;
+        try {
+            flightToLink = model.getFlightById(flightId);
+        } catch (FlightNotFoundException e) {
+            return new CommandResult(String.format("Flight id %s not found.", flightId));
+        }
+
+        Location departureLocationToLink;
+        try {
+            departureLocationToLink = model.getLocationById(departureLocationId);
+        } catch (LocationNotFoundException e) {
+            return new CommandResult(String.format("Departure location id %s not found.", departureLocationId));
+        }
+
+        Location arrivalLocationToLink;
+        try {
+            arrivalLocationToLink = model.getLocationById(arrivalLocationId);
+        } catch (LocationNotFoundException e) {
+            return new CommandResult(String.format("Arrival location id %s not found.", arrivalLocationId));
+        }
+
+        if (departureLocationToLink.equals(arrivalLocationToLink)) {
+            return new CommandResult("Departure and arrival locations cannot be the same.");
+        }
+
         model.linkFlightToLocations(flightToLink, departureLocationToLink, arrivalLocationToLink);
         return new CommandResult(
                 String.format("Linked departure location %s and arrival location %s to flight %s.",

--- a/src/main/java/seedu/address/logic/location/linklocation/LinkLocationCommand.java
+++ b/src/main/java/seedu/address/logic/location/linklocation/LinkLocationCommand.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.location.linklocation;
+
+import seedu.address.logic.core.Command;
+import seedu.address.logic.core.CommandResult;
+import seedu.address.logic.core.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.flight.Flight;
+import seedu.address.model.location.Location;
+
+
+/**
+ * The command that links departure and arrival locations to a flight.
+ */
+public class LinkLocationCommand implements Command {
+    /**
+     * The flight which the location is to be linked to.
+     */
+    private final String flightId;
+
+    /**
+     * The arrival location to link flight with.
+     */
+    private final String arrivalLocationId;
+
+    /**
+     * The departure location to link flight with.
+     */
+    private final String departureLocationId;
+
+
+    /**
+     * Creates a command to link location to a flight.
+     * @param flightId the id of the flight
+     * @param arrivalLocationId the id of the arrival location
+     * @param departureLocationId the id of the departure location
+     */
+    public LinkLocationCommand(String flightId, String departureLocationId, String arrivalLocationId) {
+        this.flightId = flightId;
+        this.departureLocationId = departureLocationId;
+        this.arrivalLocationId = arrivalLocationId;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        Flight flightToLink = model.getFlightById(flightId);
+        Location departureLocationToLink = model.getLocationById(departureLocationId);
+        Location arrivalLocationToLink = model.getLocationById(arrivalLocationId);
+        model.linkFlightToLocations(flightToLink, departureLocationToLink, arrivalLocationToLink);
+        return new CommandResult(
+                String.format("Linked departure location %s and arrival location %s to flight %s.",
+                        departureLocationId,
+                        arrivalLocationId,
+                        flightId)
+        );
+    }
+}

--- a/src/main/java/seedu/address/logic/location/linklocation/LinkLocationCommandFactory.java
+++ b/src/main/java/seedu/address/logic/location/linklocation/LinkLocationCommandFactory.java
@@ -1,0 +1,36 @@
+package seedu.address.logic.location.linklocation;
+
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.logic.core.CommandFactory;
+import seedu.address.logic.core.CommandParam;
+import seedu.address.logic.core.exceptions.ParseException;
+
+/**
+ * The factory that creates {@code AddLocationCommand}.
+ */
+public class LinkLocationCommandFactory implements CommandFactory<LinkLocationCommand> {
+    public static final String COMMAND_WORD = "link";
+    public static final String PREFIX_FLIGHT = "/flight";
+    public static final String PREFIX_DEPARTURE = "/from";
+    public static final String PREFIX_ARRIVAL = "/to";
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
+
+    @Override
+    public Optional<Set<String>> getPrefixes() {
+        return Optional.of(Set.of(PREFIX_FLIGHT, PREFIX_DEPARTURE, PREFIX_ARRIVAL));
+    }
+
+    @Override
+    public LinkLocationCommand createCommand(CommandParam param) throws ParseException {
+        final String flightId = param.getNamedValuesOrThrow(PREFIX_FLIGHT);
+        final String departureLocationId = param.getNamedValuesOrThrow(PREFIX_DEPARTURE);
+        final String arrivalLocationId = param.getNamedValuesOrThrow(PREFIX_ARRIVAL);
+        return new LinkLocationCommand(flightId, departureLocationId, arrivalLocationId);
+    }
+}

--- a/src/main/java/seedu/address/logic/location/unlinklocation/UnlinkLocationCommand.java
+++ b/src/main/java/seedu/address/logic/location/unlinklocation/UnlinkLocationCommand.java
@@ -5,6 +5,7 @@ import seedu.address.logic.core.CommandResult;
 import seedu.address.logic.core.exceptions.CommandException;
 import seedu.address.model.Model;
 import seedu.address.model.flight.Flight;
+import seedu.address.model.flight.exceptions.FlightNotFoundException;
 
 /**
  * The command that unlinks flights to departure and arrival locations.
@@ -25,7 +26,13 @@ public class UnlinkLocationCommand implements Command {
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        Flight flightToUnlink = model.getFlightById(flightId);
+        Flight flightToUnlink;
+        try {
+            flightToUnlink = model.getFlightById(flightId);
+        } catch (FlightNotFoundException e) {
+            return new CommandResult(String.format("Flight id %s not found. ", flightId));
+        }
+
         model.unlinkFlightToLocations(flightToUnlink);
         return new CommandResult(
                 String.format("Unlink departure and arrival locations from flight %s", flightId)

--- a/src/main/java/seedu/address/logic/location/unlinklocation/UnlinkLocationCommand.java
+++ b/src/main/java/seedu/address/logic/location/unlinklocation/UnlinkLocationCommand.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.location.unlinklocation;
+
+import seedu.address.logic.core.Command;
+import seedu.address.logic.core.CommandResult;
+import seedu.address.logic.core.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.flight.Flight;
+
+/**
+ * The command that unlinks flights to departure and arrival locations.
+ */
+public class UnlinkLocationCommand implements Command {
+    /**
+     * The id of the light to unlink locations.
+     */
+    private final String flightId;
+
+    /**
+     * Creates a command that unlinks a flight to locations.
+     * @param flightId the id of the flight to unlink
+     */
+    public UnlinkLocationCommand(String flightId) {
+        this.flightId = flightId;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        Flight flightToUnlink = model.getFlightById(flightId);
+        model.unlinkFlightToLocations(flightToUnlink);
+        return new CommandResult(
+                String.format("Unlink departure and arrival locations from flight %s", flightId)
+        );
+    }
+}

--- a/src/main/java/seedu/address/logic/location/unlinklocation/UnlinkLocationCommandFactory.java
+++ b/src/main/java/seedu/address/logic/location/unlinklocation/UnlinkLocationCommandFactory.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.location.unlinklocation;
+
+import java.util.Optional;
+import java.util.Set;
+
+import seedu.address.logic.core.CommandFactory;
+import seedu.address.logic.core.CommandParam;
+import seedu.address.logic.core.exceptions.ParseException;
+
+/**
+ * The factory that createsw {@code UnlinkLocationCommand}.
+ */
+public class UnlinkLocationCommandFactory implements CommandFactory<UnlinkLocationCommand> {
+    public static final String COMMAND_WORD = "unlink";
+    public static final String PREFIX_FLIGHT = "/flight";
+
+    @Override
+    public String getCommandWord() {
+        return COMMAND_WORD;
+    }
+
+    @Override
+    public Optional<Set<String>> getPrefixes() {
+        return Optional.of(Set.of(PREFIX_FLIGHT));
+    }
+
+    @Override
+    public UnlinkLocationCommand createCommand(CommandParam param) throws ParseException {
+        final String flightId = param.getNamedValuesOrThrow(PREFIX_FLIGHT);
+        return new UnlinkLocationCommand(flightId);
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -150,6 +150,13 @@ public interface Model {
     // ================ Location methods ==============================
 
     /**
+     * Returns location object by location id
+     * @param id the location id
+     * @return the location object with the id
+     */
+    Location getLocationById(String id);
+
+    /**
      * Returns true if the location is in the location list
      *
      * @param location a location object to be checked
@@ -185,6 +192,8 @@ public interface Model {
 
     void updateFilteredLocationList(Predicate<Location> predicate);
 
+    void linkFlightToLocations(Flight flight, Location departureLocation, Location arrivalLocation);
+    void unlinkFlightToLocations(Flight flight);
 
     // ================ Crew methods ==============================
 
@@ -258,6 +267,13 @@ public interface Model {
 
 
     // ================ Flight methods ==============================
+
+    /**
+     * Returns flight object by flight id
+     * @param id the flight id
+     * @return the flight object with the id
+     */
+    Flight getFlightById(String id);
 
     /**
      * Returns the flight manager

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -16,8 +16,10 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.crew.Crew;
 import seedu.address.model.flight.Flight;
+import seedu.address.model.flight.exceptions.FlightNotFoundException;
 import seedu.address.model.item.Item;
 import seedu.address.model.location.Location;
+import seedu.address.model.location.exceptions.LocationNotFoundException;
 import seedu.address.model.pilot.Pilot;
 import seedu.address.model.plane.Plane;
 
@@ -239,6 +241,20 @@ public class ModelManager implements Model {
     //=========== Location ========================================================
 
     @Override
+    public Location getLocationById(String id) {
+        Location locationToFind = null;
+        for (Location location: getFilteredLocationList()) {
+            if (location.getId().equals(id)) {
+                locationToFind = location;
+            }
+        }
+        if (locationToFind == null) {
+            throw new LocationNotFoundException();
+        }
+        return locationToFind;
+    }
+
+    @Override
     public ReadOnlyItemManager<Location> getLocationManager() {
         return locationManager;
     }
@@ -297,6 +313,19 @@ public class ModelManager implements Model {
         filteredLocations.setPredicate(predicate);
     }
 
+    @Override
+    public void linkFlightToLocations(Flight flight, Location departureLocation, Location arrivalLocation) {
+        requireAllNonNull(flight, departureLocation, arrivalLocation);
+        flight.linkDepartureLocation(departureLocation);
+        flight.linkArrivalLocation(arrivalLocation);
+    }
+
+    @Override
+    public void unlinkFlightToLocations(Flight flight) {
+        requireNonNull(flight);
+        flight.unLinkArrivalLocation();
+        flight.unLinkDepartureLocation();
+    }
 
     //=========== Crew ========================================================
 
@@ -426,6 +455,20 @@ public class ModelManager implements Model {
 
 
     //=========== Flight ========================================================
+
+    @Override
+    public Flight getFlightById(String id) {
+        Flight flightToFind = null;
+        for (Flight flight: getFilteredFlightList()) {
+            if (flight.getId().equals(id)) {
+                flightToFind = flight;
+            }
+        }
+        if (flightToFind == null) {
+            throw new FlightNotFoundException();
+        }
+        return flightToFind;
+    }
 
     @Override
     public ReadOnlyItemManager<Flight> getFlightManager() {

--- a/src/main/java/seedu/address/model/flight/Flight.java
+++ b/src/main/java/seedu/address/model/flight/Flight.java
@@ -14,6 +14,9 @@ import seedu.address.model.plane.Plane;
 public class Flight implements Item {
     private static final String UUID_STRING = "UUID";
     private static final String CODE_STRING = "Code";
+    private static final String DEPARTURE_STRING = "Depart from";
+    private static final String ARRIVE_STRING = "Arrive at";
+
     private final String code;
     private final String id;
     private Plane plane;
@@ -55,7 +58,9 @@ public class Flight implements Item {
     public List<String> getDisplayList() {
         return List.of(
                 String.format("%s: %s", UUID_STRING, id),
-                String.format("%s: %s", CODE_STRING, code)
+                String.format("%s: %s", CODE_STRING, code),
+                String.format("%s: %s", DEPARTURE_STRING, getDepartureLocationName()),
+                String.format("%s: %s", ARRIVE_STRING, getArrivalLocationName())
         );
     }
 
@@ -140,5 +145,21 @@ public class Flight implements Item {
      */
     public Location getArrivalLocation() {
         return arrivalLocation;
+    }
+
+    private String getDepartureLocationName() {
+        if (departureLocation == null) {
+            return "null";
+        } else {
+            return departureLocation.getName();
+        }
+    }
+
+    private String getArrivalLocationName() {
+        if (arrivalLocation == null) {
+            return "null";
+        } else {
+            return arrivalLocation.getName();
+        }
     }
 }

--- a/src/main/java/seedu/address/model/flight/Flight.java
+++ b/src/main/java/seedu/address/model/flight/Flight.java
@@ -5,6 +5,7 @@ import java.util.UUID;
 
 import seedu.address.model.flight.exceptions.LinkedPlaneNotFoundException;
 import seedu.address.model.item.Item;
+import seedu.address.model.location.Location;
 import seedu.address.model.plane.Plane;
 
 /**
@@ -18,6 +19,9 @@ public class Flight implements Item {
     private Plane plane;
 
     //TODO: Add departure and arrival locations
+    private Location departureLocation;
+    private Location arrivalLocation;
+
     //TODO: Add exceptions to ensure departure and arrival locations are distinct
 
     /**
@@ -90,5 +94,51 @@ public class Flight implements Item {
         } else {
             throw new LinkedPlaneNotFoundException();
         }
+    }
+
+    /**
+     * Links the flight to a departure location.
+     * @param departureLocation the departure location to link to
+     */
+    public void linkDepartureLocation(Location departureLocation) {
+        this.departureLocation = departureLocation;
+    }
+
+    /**
+     * Links the flight to an arrival location.
+     * @param arrivalLocation the arrival location to link to
+     */
+    public void linkArrivalLocation(Location arrivalLocation) {
+        this.arrivalLocation = arrivalLocation; 
+    }
+
+    /**
+     * Unlinks the departure location.
+     */
+    public void unLinkDepartureLocation() {
+        this.departureLocation = null;
+    }
+
+    /**
+     * Unlinks the arrival location.
+     */
+    public void unLinkArrivalLocation() {
+        this.arrivalLocation = null;
+    }
+
+    /**
+     * Returns the departure location of the plane.
+     * @return the departure location.
+     */
+    public Location getDepartureLocation() {
+        return departureLocation;
+    }
+
+    /**
+     * Returns the arrival location of the plane.
+     * @return the arrival location
+     */
+    public Location getArrivalLocation() {
+        return arrivalLocation;
     }
 }

--- a/src/main/java/seedu/address/model/flight/Flight.java
+++ b/src/main/java/seedu/address/model/flight/Flight.java
@@ -16,6 +16,7 @@ public class Flight implements Item {
     private static final String CODE_STRING = "Code";
     private static final String DEPARTURE_STRING = "Depart from";
     private static final String ARRIVE_STRING = "Arrive at";
+    private static final String NOT_SPECIFIED_STRING = "Not Specified";
 
     private final String code;
     private final String id;
@@ -114,7 +115,7 @@ public class Flight implements Item {
      * @param arrivalLocation the arrival location to link to
      */
     public void linkArrivalLocation(Location arrivalLocation) {
-        this.arrivalLocation = arrivalLocation; 
+        this.arrivalLocation = arrivalLocation;
     }
 
     /**
@@ -147,19 +148,59 @@ public class Flight implements Item {
         return arrivalLocation;
     }
 
-    private String getDepartureLocationName() {
+    /**
+     * Returns the id of the departure location.
+     * @return the id of the departure location
+     */
+    public String getDepartureLocationId() {
         if (departureLocation == null) {
-            return "null";
+            return NOT_SPECIFIED_STRING;
+        } else {
+            return departureLocation.getId();
+        }
+    }
+
+    /**
+     * Returns departure location name.
+     * @return the name of the departure location
+     */
+    public String getDepartureLocationName() {
+        if (departureLocation == null) {
+            return NOT_SPECIFIED_STRING;
         } else {
             return departureLocation.getName();
         }
     }
 
+    /**
+     * Returns the id of the arrival location.
+     * @return the id of the arrival location
+     */
+    public String getArrivalLocationId() {
+        if (departureLocation == null) {
+            return NOT_SPECIFIED_STRING;
+        } else {
+            return arrivalLocation.getId();
+        }
+    }
+
+    /**
+     * Returns arrival location name.
+     * @return the name of the arrival location
+     */
     private String getArrivalLocationName() {
         if (arrivalLocation == null) {
-            return "null";
+            return NOT_SPECIFIED_STRING;
         } else {
             return arrivalLocation.getName();
         }
+    }
+
+    /**
+     * Returns whether the location has linked locations
+     * @return true if there are linked locations
+     */
+    public boolean hasLinkedLocations() {
+        return arrivalLocation != null && departureLocation != null;
     }
 }

--- a/src/main/java/seedu/address/model/location/Location.java
+++ b/src/main/java/seedu/address/model/location/Location.java
@@ -62,12 +62,12 @@ public class Location implements Item {
      * Returns true if both locations have the same name.
      * This defines a weaker notion of equality between two locations.
      */
-    public boolean isSameLocation(Location otherLocation) {
+    public boolean equals(Location otherLocation) {
         if (otherLocation == this) {
             return true;
         }
 
         return otherLocation != null
-                && otherLocation.getName().equals(getName());
+                && otherLocation.getId().equals(getId());
     }
 }

--- a/src/main/java/seedu/address/storage/json/adapted/JsonAdaptedFlight.java
+++ b/src/main/java/seedu/address/storage/json/adapted/JsonAdaptedFlight.java
@@ -1,7 +1,5 @@
 package seedu.address.storage.json.adapted;
 
-
-import com.fasterxml.jackson.annotation.JacksonAnnotation;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 

--- a/src/main/java/seedu/address/storage/json/adapted/JsonAdaptedFlight.java
+++ b/src/main/java/seedu/address/storage/json/adapted/JsonAdaptedFlight.java
@@ -29,6 +29,7 @@ public class JsonAdaptedFlight implements JsonAdaptedModel<Flight> {
      */
     private String plane;
 
+
     /**
      * Constructs a {@code JsonAdaptedFlight} with the given flight details.
      * This is intended for Jackson to use.

--- a/src/main/java/seedu/address/storage/json/adapted/JsonAdaptedFlight.java
+++ b/src/main/java/seedu/address/storage/json/adapted/JsonAdaptedFlight.java
@@ -1,11 +1,13 @@
 package seedu.address.storage.json.adapted;
 
 
+import com.fasterxml.jackson.annotation.JacksonAnnotation;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.flight.Flight;
+import seedu.address.model.location.Location;
 import seedu.address.storage.json.JsonAdaptedModel;
 
 /**
@@ -29,6 +31,14 @@ public class JsonAdaptedFlight implements JsonAdaptedModel<Flight> {
      */
     private String plane;
 
+    /**
+     * Location related attributes.
+     */
+    private boolean hasLinkedLocations;
+    private String departureLocationId;
+    private String departureLocationName;
+    private String arrivalLocationId;
+    private String arrivalLocationName;
 
     /**
      * Constructs a {@code JsonAdaptedFlight} with the given flight details.
@@ -36,14 +46,29 @@ public class JsonAdaptedFlight implements JsonAdaptedModel<Flight> {
      *
      * @param id   The id of the flight.
      * @param code The name of the flight.
+     * @param hasLinkedLocations Whether the flight is linked to locations.
+     * @param departureLocationId The id of the departure location.
+     * @param departureLocationName The name of the departure location.
+     * @param arrivalLocationId The id of the arrival location.
+     * @param arrivalLocationName The name of the arrival location.
      */
     @JsonCreator
     public JsonAdaptedFlight(@JsonProperty("id") String id,
                              @JsonProperty("code") String code,
-                             @JsonProperty("plane") String plane) {
+                             @JsonProperty("plane") String plane,
+                             @JsonProperty("hasLinkedLocations") boolean hasLinkedLocations,
+                             @JsonProperty("departureLocationId") String departureLocationId,
+                             @JsonProperty("departureLocationName") String departureLocationName,
+                             @JsonProperty("arrivalLocationId") String arrivalLocationId,
+                             @JsonProperty("arrivalLocationName") String arrivalLocationName) {
         this.id = id;
         this.code = code;
         this.plane = plane;
+        this.hasLinkedLocations = hasLinkedLocations;
+        this.departureLocationId = departureLocationId;
+        this.departureLocationName = departureLocationName;
+        this.arrivalLocationId = arrivalLocationId;
+        this.arrivalLocationName = arrivalLocationName;
     }
 
     /**
@@ -60,6 +85,16 @@ public class JsonAdaptedFlight implements JsonAdaptedModel<Flight> {
         } else {
             this.plane = "";
         }
+
+        if (flight.hasLinkedLocations()) {
+            this.hasLinkedLocations = true;
+            this.departureLocationName = flight.getDepartureLocationName();
+            this.departureLocationId = flight.getDepartureLocationId();
+            this.arrivalLocationName = flight.getDepartureLocationName();
+            this.arrivalLocationId = flight.getArrivalLocationId();
+        } else {
+            this.hasLinkedLocations = false;
+        }
     }
 
     @Override
@@ -71,6 +106,18 @@ public class JsonAdaptedFlight implements JsonAdaptedModel<Flight> {
             throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "code"));
         }
 
-        return new Flight(id, code);
+        Flight flight = new Flight(id, code);
+        if (hasLinkedLocations) {
+            if (departureLocationId == null || departureLocationName == null
+                    || arrivalLocationId == null || arrivalLocationName == null) {
+                throw new IllegalValueException(String.format(MISSING_FIELD_MESSAGE_FORMAT, "locations"));
+            }
+            Location departureLocation = new Location(departureLocationId, departureLocationName);
+            Location arrivalLocation = new Location(arrivalLocationId, arrivalLocationName);
+            flight.linkDepartureLocation(departureLocation);
+            flight.linkArrivalLocation(arrivalLocation);
+        }
+
+        return flight;
     }
 }


### PR DESCRIPTION
Please do not approve this yet.

TODO:
1. Enable storage by modifying JsonAdaptedFlight: how to save an object attribute?
2. Raise exceptions when (1) arrival and departure locations are the same, (2) unlink flights without linked locations, and possibly (3) link flights that are already linked with locations 
3. Display error, e.g., flight not found, in GUI